### PR TITLE
fix: simplify to Pumas 2.3.1 syntax

### DIFF
--- a/day1-03-poppk1.jl
+++ b/day1-03-poppk1.jl
@@ -47,10 +47,10 @@ params = (tvcl = 1.0, tvvc = 10.0, Ω = Diagonal([0.09, 0.09]), σ = 3.16)
 params2 = (tvcl = 1.0, tvvc = 8.0, Ω = Diagonal([0.5, 0.5]), σ = 4.16)
 
 # Fit a base model
-fit_results = fit(model, population, params, Pumas.FOCE())
-fit_results2 = fit(model, population, params, Pumas.FOCE(); constantcoef = (Ω = Diagonal(zeros(2)),)) # Turn off random effects
-fit_results3 = fit(model, population, params2, Pumas.LaplaceI())
-fit_results4 = fit(model, population, params2, Pumas.FOCE(); constantcoef = (tvcl = 1.0,))
+fit_results = fit(model, population, params, FOCE())
+fit_results2 = fit(model, population, params, FOCE(); constantcoef = (Ω = Diagonal(zeros(2)),)) # Turn off random effects
+fit_results3 = fit(model, population, params2, LaplaceI())
+fit_results4 = fit(model, population, params2, FOCE(); constantcoef = (tvcl = 1.0,))
 
 fit_compare = compare_estimates(;
     FOCE = fit_results,

--- a/day1-04-iterative.jl
+++ b/day1-04-iterative.jl
@@ -96,7 +96,7 @@ end
 params_1cmt_comb =
     (tvvc = 5, tvcl = 0.2, Ω = Diagonal([0.09, 0.09]), σ²_add = 0.01, σ²_prop = 0.01)
 
-pkfit_1cmt_comb = fit(pk_1cmt, pop, params_1cmt_comb, Pumas.FOCE())
+pkfit_1cmt_comb = fit(pk_1cmt, pop, params_1cmt_comb, FOCE())
 
 ## Show Model diagnistic criteria (more on day 2)
 metrics_pkfit_1cmt_comb = metrics_table(pkfit_1cmt_comb)
@@ -108,7 +108,7 @@ infer_1cmt_comb = infer(pkfit_1cmt_comb) # computes variance-covariance matrix C
 coeftable(infer_1cmt_comb) # returns a table with parameter, se, ci lower and ci upper
 
 ##  look at the influenntial individuals                     
-pk_influential = findinfluential(pk_1cmt, pop, params_1cmt_comb, Pumas.FOCE())
+pk_influential = findinfluential(pk_1cmt, pop, params_1cmt_comb, FOCE())
 
 ## Save your fitted model 
 serialize("pkfit_1cmt_comb.jls", pkfit_1cmt_comb)
@@ -194,18 +194,18 @@ params_2cmt_comb = (
 
 
 ## Maximum likelihood estimation
-pkfit_2cmt_comb = fit(pk_2cmt, pop, params_2cmt_comb, Pumas.FOCE())
+pkfit_2cmt_comb = fit(pk_2cmt, pop, params_2cmt_comb, FOCE())
 ##  you can quickly check proportional and additive error as well
 pkfit_2cmt_add = fit(
     pk_2cmt,
     pop,
     params_2cmt_comb,
     constantcoef = (σ²_prop = 0,), # sets a parameter to a fixed value
-    Pumas.FOCE(),
+    FOCE(),
 )
 
 pkfit_2cmt_prop =
-    fit(pk_2cmt, pop, params_2cmt_comb, constantcoef = (σ²_add = 0,), Pumas.FOCE())
+    fit(pk_2cmt, pop, params_2cmt_comb, constantcoef = (σ²_add = 0,), FOCE())
 
 # Serialize fits 
 serialize("pk_fit_2cmt_comb.jls", pkfit_2cmt_comb)
@@ -295,7 +295,7 @@ params_base_wt = (
 
 
 ## Maximum likelihood estimation
-pkfit_base_wt = fit(pk_base_wt, pop, params_base_wt, Pumas.FOCE())
+pkfit_base_wt = fit(pk_base_wt, pop, params_base_wt, FOCE())
 
 serialize("pkfit_base_wt.jls", pkfit_base_wt)
 pkfit_base_wt = deserialize("pkfit_base_wt.jls")
@@ -380,7 +380,7 @@ params_base_wt_crcl = (
 
 
 ## Maximum likelihood estimation
-pkfit_base_wt_crcl = fit(pk_base_wt_crcl, pop, params_base_wt_crcl, Pumas.FOCE())
+pkfit_base_wt_crcl = fit(pk_base_wt_crcl, pop, params_base_wt_crcl, FOCE())
 
 
 serialize("pkfit_base_wt_crcl.jls", pkfit_base_wt_crcl)

--- a/day1-05-absorption_models.jl
+++ b/day1-05-absorption_models.jl
@@ -41,7 +41,7 @@ end
 
 param_foabs = (tvcl = 5, tvvc = 20, tvka = 1, Ω = Diagonal([0.04, 0.04, 0.04]), σ = 1.0)
 
-fit_foabs = fit(foabs, pop_oral, param_foabs, Pumas.FOCE())
+fit_foabs = fit(foabs, pop_oral, param_foabs, FOCE())
 
 # Zero-Order Absorption
 zoabs = @model begin
@@ -79,7 +79,7 @@ end
 
 param_zoabs = (tvcl = 5, tvvc = 20, tvdur = 0.3, Ω = Diagonal([0.04, 0.04, 0.04]), σ = 1.0)
 
-fit_zoabs = fit(zoabs, pop_dur, param_zoabs, Pumas.FOCE())
+fit_zoabs = fit(zoabs, pop_dur, param_zoabs, FOCE())
 
 # Two Parallel First-Order Processes
 two_parallel_foabs = @model begin
@@ -131,4 +131,4 @@ param_two_parallel_foabs = (
 )
 
 fit_two_parallel_foabs =
-    fit(two_parallel_foabs, pop_oral, param_two_parallel_foabs, Pumas.FOCE())
+    fit(two_parallel_foabs, pop_oral, param_two_parallel_foabs, FOCE())

--- a/day2-01-model_diagnostics-model_qualification.jl
+++ b/day2-01-model_diagnostics-model_qualification.jl
@@ -62,26 +62,26 @@ params =
     (tvvc = 5, tvcl = 0.02, tvq = 0.01, tvvp = 10, Ω = Diagonal([0.01, 0.01]), σ = 0.01)
 
 # Fit models
-fit_results = fit(model, pop, params, Pumas.FOCE())
-fit_results_naive = fit(model, pop, params, Pumas.FOCE(); constantcoef = (Ω = Diagonal(zeros(2)),)) # Turn off random effects
-fit_results_fixed = fit(model, pop, params, Pumas.FOCE(); constantcoef = (tvcl = 0.3,))
+fit_results = fit(model, pop, params, FOCE())
+fit_results_naive = fit(model, pop, params, FOCE(); constantcoef = (Ω = Diagonal(zeros(2)),)) # Turn off random effects
+fit_results_fixed = fit(model, pop, params, FOCE(); constantcoef = (tvcl = 0.3,))
 
 # Confidence Intervals using asymptotic variance-covariance
 fit_infer = infer(fit_results)
 coeftable(fit_infer)  # DataFrame
 
 # Confidence Intervals using bootstrap
-fit_infer_bs = infer(fit_results, Pumas.Bootstrap(samples = 100))
+fit_infer_bs = infer(fit_results, Bootstrap(samples = 100))
 coeftable(fit_infer_bs)
 
 # Confidence Intervals using SIR
-fit_infer_sir = infer(fit_results, Pumas.SIR(samples = 10, resamples = 10))
+fit_infer_sir = infer(fit_results, SIR(samples = 10, resamples = 10))
 coeftable(fit_infer_sir)
 
 # Loglikelihood and NONMEM's OFV with constant
 loglikelihood(fit_results) # using a result from fit
-loglikelihood(model, pop, coef(fit_results), Pumas.FOCE()) # using model + population + params + estimation method
-loglikelihood(model, pop[1], coef(fit_results), Pumas.FOCE()) # using model + subject + params + estimation method
+loglikelihood(model, pop, coef(fit_results), FOCE()) # using model + population + params + estimation method
+loglikelihood(model, pop[1], coef(fit_results), FOCE()) # using model + subject + params + estimation method
 # to reproduce NONMEM's "OFV with constant" you need to divide by -2
 loglikelihood(fit_results) / -2
 

--- a/day2-01-model_diagnostics.jl
+++ b/day2-01-model_diagnostics.jl
@@ -78,11 +78,11 @@ params =
     (tvvc = 5, tvcl = 0.02, tvq = 0.01, tvvp = 10, allometric = 1.0, Ω = Diagonal([0.01, 0.01]), σ = 0.01)
 
 # Check for finite loglikelihood
-loglikelihood(model, pop, params, Pumas.FOCE()) # using model + population + params + estimation method
-findinfluential(model, pop, params, Pumas.FOCE(); k = 30)
+loglikelihood(model, pop, params, FOCE()) # using model + population + params + estimation method
+findinfluential(model, pop, params, FOCE(); k = 30)
 
 # Fit model
-fit_results_base = fit(model, pop, params, Pumas.FOCE(); constantcoef=(allometric=0.0,))
+fit_results_base = fit(model, pop, params, FOCE(); constantcoef=(allometric=0.0,))
 
 # Model metrics in a DataFrame
 fit_results_base_metrics = metrics_table(fit_results_base)
@@ -144,7 +144,7 @@ empirical_bayes_vs_covariates(fit_inspect_base;
     markersize=5,)
 
 # Fit allometric scaling model
-fit_results_allometric = fit(model, pop, params, Pumas.FOCE(); constantcoef=(allometric=1.0,))
+fit_results_allometric = fit(model, pop, params, FOCE(); constantcoef=(allometric=1.0,))
 compare_estimates(;fit_results_base, fit_results_allometric)
 
 fit_inspect_allometric = inspect(fit_results_allometric)
@@ -160,26 +160,26 @@ coeftable(fit_results_allometric)  # DataFrame
 stderror(fit_infer)
 
 ## Confidence Intervals using bootstrap
-fit_infer_bs = infer(fit_results_allometric, Pumas.Bootstrap(samples = 100))
+fit_infer_bs = infer(fit_results_allometric, Bootstrap(samples = 100))
 coeftable(fit_infer_bs)
 stderror(fit_infer)
 DataFrame(fit_infer_bs.vcov)
 
 ## Stratified sampling of subjects
-fit_infer_bs_stratify = infer(fit_results_allometric, Pumas.Bootstrap(samples = 100, stratify_by=:WT))
+fit_infer_bs_stratify = infer(fit_results_allometric, Bootstrap(samples = 100, stratify_by=:WT))
 coeftable(fit_infer_bs_stratify)
 stderror(fit_infer)
 
 # Seed
 rng = Random.seed!(2131)
-fit_infer_bs_rng_1 = infer(fit_results_allometric, Pumas.Bootstrap(;samples = 20, rng))
+fit_infer_bs_rng_1 = infer(fit_results_allometric, Bootstrap(;samples = 20, rng))
 rng = Random.seed!(2131)
-fit_infer_bs_rng_2 = infer(fit_results_allometric, Pumas.Bootstrap(;samples = 20, rng))
+fit_infer_bs_rng_2 = infer(fit_results_allometric, Bootstrap(;samples = 20, rng))
 coeftable(fit_infer_bs_rng_1)
 coeftable(fit_infer_bs_rng_2)
 
 ## Confidence Intervals using SIR
-fit_infer_sir = infer(fit_results_allometric, Pumas.SIR(samples = 100, resamples = 10))
+fit_infer_sir = infer(fit_results_allometric, SIR(samples = 100, resamples = 10))
 coeftable(fit_infer_sir)
 
 # VPCs

--- a/day2-02-model_diagnostics-plotting.jl
+++ b/day2-02-model_diagnostics-plotting.jl
@@ -62,20 +62,20 @@ params =
     (tvvc = 5, tvcl = 0.02, tvq = 0.01, tvvp = 10, Ω = Diagonal([0.01, 0.01]), σ = 0.01)
 
 # Fit models
-fit_results = fit(model, pop, params, Pumas.FOCE())
-fit_results_naive = fit(model, pop, params, Pumas.FOCE(); constantcoef = (Ω = Diagonal(zeros(2)),)) # Turn off random effects
-fit_results_fixed = fit(model, pop, params, Pumas.FOCE(); constantcoef = (tvcl = 0.3,))
+fit_results = fit(model, pop, params, FOCE())
+fit_results_naive = fit(model, pop, params, FOCE(); constantcoef = (Ω = Diagonal(zeros(2)),)) # Turn off random effects
+fit_results_fixed = fit(model, pop, params, FOCE(); constantcoef = (tvcl = 0.3,))
 
 # Confidence Intervals
 fit_infer = infer(fit_results)
 coeftable(fit_infer)  # DataFrame
 
 # Confidence Intervals using bootstrap
-fit_infer_bs = infer(fit_results, Pumas.Bootstrap(samples = 100))
+fit_infer_bs = infer(fit_results, Bootstrap(samples = 100))
 coeftable(fit_infer_bs)
 
 # Confidence Intervals using SIR
-fit_infer_sir = infer(fit_results, Pumas.SIR(samples = 10, resamples = 10))
+fit_infer_sir = infer(fit_results, SIR(samples = 10, resamples = 10))
 coeftable(fit_infer_sir)
 
 # Inspect the models
@@ -90,7 +90,7 @@ observations_vs_ipredictions(fit_inspect)
 wresiduals_vs_time(fit_inspect)
 iwresiduals_vs_ipredictions(fit_inspect)
 # using custom likelihood approx
-fit_wres = wresiduals(fit_results, Pumas.FO())
+fit_wres = wresiduals(fit_results, FO())
 wresiduals_vs_time(model, fit_wres) # using model + custom wresiduals
 # using custom predict
 fit_predict = predict(fit_results)

--- a/day2-03-sequential_PKPD.jl
+++ b/day2-03-sequential_PKPD.jl
@@ -68,7 +68,7 @@ twocomp_params = (
 #
 
 # 5. Fit the data
-pkfit = fit(inf_2cmt, pkpdpop, twocomp_params, Pumas.FOCE())
+pkfit = fit(inf_2cmt, pkpdpop, twocomp_params, FOCE())
 
 # 6. explore the results
 pkinspect = inspect(pkfit)
@@ -154,7 +154,7 @@ turnover_params =
     (tvturn = 10, tvebase = 10, tvec50 = 0.3, Ω_pd = Diagonal([0.05]), σ_add_pd = 0.2)
 
 # 11. Fit the PD data via sequential pkpd
-pkpdfit = fit(inf_2cmt_lin_turnover, pdpop, turnover_params, Pumas.FOCE())
+pkpdfit = fit(inf_2cmt_lin_turnover, pdpop, turnover_params, FOCE())
 
 # 12. explore the results
 pdinspect = inspect(pkpdfit)

--- a/day2-extra-tte.jl
+++ b/day2-extra-tte.jl
@@ -56,7 +56,7 @@ tte_single_weibull_fit = fit(
     tte_single_weibull_model,
     pop_single,
     init_params(tte_single_weibull_model),
-    Pumas.LaplaceI(),
+    LaplaceI(),
 )
 
 # Simulations


### PR DESCRIPTION
This PR removes the `Pumas.*()` from calls like `Pumas.FOCE()`, `Pumas.Bootstrap()`, `Pumas.SAEM()`, etc.